### PR TITLE
Fix: also use westus location in common workflow

### DIFF
--- a/.github/workflows/day5-scm-common.yml
+++ b/.github/workflows/day5-scm-common.yml
@@ -93,7 +93,7 @@ jobs:
     needs: deploy-to-dev
     env:
       RESOURCE_GROUP_NAME: rg-scm-testday5
-      RESOURCE_GROUP_LOCATION: westeurope
+      RESOURCE_GROUP_LOCATION: westus
       ENV_NAME: testd5
 
     steps:


### PR DESCRIPTION
This belongs to the aad-common branch noramlly. :-(